### PR TITLE
pin concourse version to v5.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: concourse_pass
 
   web:
-    image: concourse/concourse
+    image: concourse/concourse:5.6.0
     command: web
     links: [db]
     depends_on: [db]


### PR DESCRIPTION
Pinning the version ensures that this demo can be used even after breaking changes which are not reflected in this repository.